### PR TITLE
Bug Fixed: getElementsByClassName returns an array but event listener…

### DIFF
--- a/summer.js
+++ b/summer.js
@@ -1,4 +1,7 @@
-document.getElementsByClassName('cards').addEventListener('click',function(){
-    console.log('fuck');
-})
-console.log('cdi')
+let cards = document.getElementsByClassName("cards");
+for (let i = 0; i < cards.length; i++) {
+	cards[i].addEventListener("click", function () {
+		console.log("fuck");
+	});
+}
+console.log("cdi");


### PR DESCRIPTION
addEventListener works on a single element. But getElementsByClassName returns an array element. So, iterated on the array with a for loop and used addEventListener on all the single elements.